### PR TITLE
fix: Update Dependabot config to use "fix(deps)" for prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,7 @@ updates:
       - "dependencies"
       - "python"
     commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      scope: "deps"
+      prefix: "fix(deps)"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
 
@@ -26,8 +24,6 @@ updates:
       - "dependencies"
       - "docker"
     commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      scope: "deps"
+      prefix: "fix(deps)"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"


### PR DESCRIPTION
Revised the commit message prefix to "fix(deps)" for clarity and consistency. Removed redundant development-specific prefixes and scope fields in the configuration. This ensures more standardized and concise commit messages for dependency updates.